### PR TITLE
update import command to work with redis and ioredis client

### DIFF
--- a/lib/node-redis-dump.js
+++ b/lib/node-redis-dump.js
@@ -417,7 +417,7 @@ RedisDump.prototype.import = function(params) {
 				}
 
 				callArgs.push(Callback);
-				this.getClient()[ command ].apply(this.getClient(), callArgs);
+				this.getClient()[ command.toLowerCase() ].apply(this.getClient(), callArgs);
 			}.bind(this);
 
 			AddRecursive();
@@ -430,3 +430,4 @@ RedisDump.prototype.import = function(params) {
 		params.callback(err, report);
 	});
 };
+

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"node": "*"
 	},
 	"dependencies": {
-		"underscore": "~1.5.2",
-		"redis": "~0.8.4",
-		"async": "~0.2.9"
+		"underscore": "~1.9.1",
+		"redis": "~2.8.0",
+		"async": "~2.6.1"
 	},
 	"main": "./index.js",
 	"readmeFilename": "README.md",


### PR DESCRIPTION
the import function needed a small fix to either work with recent "redis" client library as well as the "ioredis" library. Now it does not matter if I specify either the one or the other libraries as client lib for your constructor.

I updated the dependencies too to use more recent versions than yours to be better usable with newer projects.

remark - this update wil make the import featur for redis-commander work too