### PR TITLE
Fix import for quoted string values with spaces

### DIFF
--- a/lib/node-redis-dump.js
+++ b/lib/node-redis-dump.js
@@ -391,30 +391,40 @@ RedisDump.prototype.import = function(params) {
 					command = items.pop(),
 					callArgs = [];
 
-				switch (command) {
-					case 'SET':
-					case 'SADD':
-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?(?:\\s|$)', 'i')).slice(1, 3);
-						break;
+                try {
+                    switch (command) {
+                        case 'SET':
+                        case 'SADD':
+                        case 'LPUSH':
+                        case 'LPUSHX':
+                        case 'RPUSH':
+                        case 'RPUSHX':
+                            // only simple form with one value is allowed, no options (EX, NX, ...)
+                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+(["\'](.+?)["\']|(.+?))(?:\\s|$)', 'i')).slice(1, 3);
+                            callArgs[1] = callArgs[1].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
+                            break;
 
-					case 'RPUSH':
-					case 'LPUSH':
-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?(?:\\s|$)', 'i')).slice(1, 3);
-						break;
+                        case 'ZADD':
+                        case 'LSET':
+                            // only simple form with one value: "ZADD key 1 value", no options (NX, XX, ...)
+                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?\\s+(["\'](.+?)["\']|(.+?))(\\s|$)', 'i')).slice(1, 4);
+                            callArgs[2] = callArgs[2].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
+                            break;
 
-					case 'ZADD':
-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?\\s+"?(.+?)"?(\\s|$)', 'i')).slice(1, 4);
-						break;
+                        case 'HSET':
+                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?\\s+(["\'](.+?)["\']|(.+?))(\\s|$)', 'i')).slice(1, 4);
+                            callArgs[2] = callArgs[2].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
+                            break;
 
-					case 'HSET':
-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?\\s+"?(.+?)"?(\\s|$)', 'i')).slice(1, 4);
-						break;
-
-					default:
-						console.error(command, args);
-						callback('Error import data! Not supported type!');
-						return;
-				}
+                        default:
+                            console.error(command, args);
+                            callback('Error import data! Not supported type!');
+                            return;
+                    }
+                }
+                catch (errCmd) {
+                    callback('FAIL parse command of known type');
+                }
 
 				callArgs.push(Callback);
 				this.getClient()[ command ].apply(this.getClient(), callArgs);


### PR DESCRIPTION
* fix import for quoted string values with spaces in between (e.g. SET key "Hello World")
* add LPUSHX, RPUSHX, LSET to allowed commands for import
* do not crash if known redis command cannot be parsed